### PR TITLE
Ensure monotonic W&B logging steps and expose architecture hyperparameters

### DIFF
--- a/Training.py
+++ b/Training.py
@@ -15,7 +15,14 @@ def parse_args():
     p.add_argument("--data", type=Path, default=Path("data/ESC-50-master"))
     p.add_argument("--epochs", type=int, default=150)
     p.add_argument("--batch_size", type=int, default=16)
-    p.add_argument("--lr", type=float, default=1e-3)
+    p.add_argument("--learning_rate", type=float, default=1e-3)
+    p.add_argument("--conv1_channels", type=int, default=32)
+    p.add_argument("--conv2_channels", type=int, default=64)
+    p.add_argument("--conv_kernel1", type=int, default=3)
+    p.add_argument("--conv_kernel2", type=int, default=3)
+    p.add_argument("--rnn_hidden", type=int, default=128)
+    p.add_argument("--rnn_layers", type=int, default=2)
+    p.add_argument("--rnn_type", choices=["GRU", "LSTM"], default="GRU")
     p.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
     return p.parse_args()
 
@@ -24,22 +31,38 @@ def parse_args():
 def main():
     args = parse_args()
     device = torch.device(args.device)
-    ds = Dataset(root_dir="data/ESC-50-master", folds=[1, 2, 3, 4], sample_rate=44100, n_mels=64)
-    ds2 = Dataset(root_dir="data/ESC-50-master", folds=[5], sample_rate=44100, n_mels=64)
-
-    train_loader = DataLoader(ds, batch_size=args.batch_size, shuffle=True)
-    val_loader = DataLoader(ds2, batch_size=args.batch_size, shuffle=False)
-
-    model = CRNN(n_mels=64, n_classes=50)
-    criterion = nn.CrossEntropyLoss()
-    optimizer = optim.Adam(model.parameters(), lr=args.lr)
-    model.to(device)
+    ds = Dataset(root_dir=args.data, folds=[1, 2, 3, 4], sample_rate=44100, n_mels=64)
+    ds2 = Dataset(root_dir=args.data, folds=[5], sample_rate=44100, n_mels=64)
 
     wandb.init(project="animal_sound_classification", config={
         "epochs": args.epochs,
         "batch_size": args.batch_size,
-        "learning_rate": args.lr,
+        "learning_rate": args.learning_rate,
+        "conv1_channels": args.conv1_channels,
+        "conv2_channels": args.conv2_channels,
+        "conv_kernel1": args.conv_kernel1,
+        "conv_kernel2": args.conv_kernel2,
+        "rnn_hidden": args.rnn_hidden,
+        "rnn_layers": args.rnn_layers,
+        "rnn_type": args.rnn_type,
     })
+    config = wandb.config
+
+    train_loader = DataLoader(ds, batch_size=config.batch_size, shuffle=True)
+    val_loader = DataLoader(ds2, batch_size=config.batch_size, shuffle=False)
+
+    model = CRNN(
+        n_mels=64,
+        n_classes=50,
+        conv_channels=(config.conv1_channels, config.conv2_channels),
+        conv_kernels=(config.conv_kernel1, config.conv_kernel2),
+        rnn_hidden=config.rnn_hidden,
+        rnn_layers=config.rnn_layers,
+        rnn_type=config.rnn_type,
+    )
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=config.learning_rate)
+    model.to(device)
     wandb.watch(model, log="all")
 
     activations = {}
@@ -53,10 +76,10 @@ def main():
         if isinstance(module, (nn.Conv2d, nn.Linear)):
             module.register_forward_hook(save_activation(name))
 
-    for epoch in range(args.epochs):
+    for epoch in range(config.epochs):
         model.train()
         total_loss = 0.0
-        for x, y in tqdm(train_loader, desc=f"Epoch {epoch+1}/{args.epochs}"):
+        for x, y in tqdm(train_loader, desc=f"Epoch {epoch+1}/{config.epochs}"):
             x, y = x.to(device), y.to(device)
             optimizer.zero_grad()
             output = model(x)
@@ -65,12 +88,7 @@ def main():
             optimizer.step()
             total_loss += loss.item()*x.size(0)
         avg_loss = total_loss / len(train_loader.dataset)
-        print(f"Epoch {epoch+1}/{args.epochs}, Loss: {avg_loss:.4f}")
-        wandb.log({
-            "train_loss": avg_loss,
-            "learning_rate": optimizer.param_groups[0]["lr"],
-            "epoch": epoch + 1,
-        })
+        print(f"Epoch {epoch+1}/{config.epochs}, Loss: {avg_loss:.4f}")
 
         model.eval()
         correct = 0
@@ -82,10 +100,16 @@ def main():
                 correct += (predicted == y).sum().item()
         accuracy = correct / len(val_loader.dataset)
         print(f"Validation Accuracy: {accuracy:.4f}")
-        wandb.log({"val_accuracy": accuracy, "epoch": epoch + 1})
 
+        log_data = {
+            "train_loss": avg_loss,
+            "learning_rate": optimizer.param_groups[0]["lr"],
+            "val_accuracy": accuracy,
+            "epoch": epoch + 1,
+        }
         for name, tensor in activations.items():
-            wandb.log({f"activations/{name}": wandb.Histogram(tensor)}, step=epoch + 1)
+            log_data[f"activations/{name}"] = wandb.Histogram(tensor)
+        wandb.log(log_data, step=epoch + 1)
         activations.clear()
 
         torch.save(model.state_dict(), f"model_epoch_{epoch+1}.pth")


### PR DESCRIPTION
## Summary
- consolidate epoch metrics and activation histograms into a single `wandb.log` call with explicit step
- allow training hyperparameters and CRNN architecture (conv layers and RNN type/size) to be overridden via W&B sweeps

## Testing
- `python -m py_compile Training.py model.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68943793d7f48326b9872bd4c8aec462